### PR TITLE
feat: добавлен таб 'Сырые данные' с фильтрами по датам, пользователю …

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,11 +5,13 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir uvicorn
+
 COPY . /app
 # Remove data directory from container - it will be mounted as volume
 RUN rm -rf /app/app/data
-
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir fastapi uvicorn "pandas>=2.3,<3.0" "pydantic>=2.7,<3.0"
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -6,7 +6,7 @@ from os import getenv
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from fastapi.encoders import jsonable_encoder
 
 from app.repositories import CSVUsageRepository
@@ -64,5 +64,21 @@ def get_tokens_by_model(
     """Return total tokens consumed per model as JSON."""
 
     dataframe = service.tokens_by_model()
+    records = dataframe.to_dict(orient="records")
+    return jsonable_encoder(records)
+
+
+@analytics_router.get("/raw_data")
+def get_raw_data(
+    start_date: str | None = Query(None, description="Start date in ISO format (e.g., 2025-09-25)"),
+    end_date: str | None = Query(None, description="End date in ISO format (e.g., 2025-09-26)"),
+    user: str | None = Query(None, description="Filter by specific user email"),
+    model: str | None = Query(None, description="Filter by specific model name"),
+    _t: str | None = Query(None, description="Timestamp to prevent caching (ignored)"),
+    service: UsageAnalyticsService = Depends(get_usage_analytics_service),
+) -> list[dict[str, Any]]:
+    """Return raw usage data with optional filtering by date range, user, and model."""
+
+    dataframe = service.get_raw_data(start_date=start_date, end_date=end_date, user=user, model=model)
     records = dataframe.to_dict(orient="records")
     return jsonable_encoder(records)

--- a/backend/app/tests/test_analytics_router.py
+++ b/backend/app/tests/test_analytics_router.py
@@ -19,6 +19,50 @@ class DummyUsageAnalyticsService:
             ]
         )
 
+    def get_raw_data(self, start_date: str | None = None, end_date: str | None = None, user: str | None = None, model: str | None = None) -> pd.DataFrame:
+        # Return test data that can be filtered
+        all_data = [
+            {
+                "date": "2024-01-01T12:00:00Z",
+                "user": "alice",
+                "kind": "chat",
+                "model": "gpt-4",
+                "max_mode": "auto",
+                "input_with_cache": 10,
+                "input_without_cache": 0,
+                "cache_read": 0,
+                "output_tokens": 15,
+                "total_tokens": 25,
+                "requests": 1,
+            },
+            {
+                "date": "2024-01-02T09:00:00Z",
+                "user": "bob",
+                "kind": "chat",
+                "model": "gpt-3.5",
+                "max_mode": "auto",
+                "input_with_cache": 5,
+                "input_without_cache": 0,
+                "cache_read": 0,
+                "output_tokens": 10,
+                "total_tokens": 15,
+                "requests": 2,
+            },
+        ]
+        
+        # Simple filtering logic for testing
+        filtered_data = all_data
+        if user:
+            filtered_data = [item for item in filtered_data if item["user"] == user]
+        if model:
+            filtered_data = [item for item in filtered_data if item["model"] == model]
+        if start_date:
+            filtered_data = [item for item in filtered_data if item["date"] >= start_date]
+        if end_date:
+            filtered_data = [item for item in filtered_data if item["date"] <= end_date]
+            
+        return pd.DataFrame(filtered_data)
+
 
 def test_tokens_per_user_endpoint_returns_expected_payload() -> None:
     app = FastAPI()
@@ -36,4 +80,169 @@ def test_tokens_per_user_endpoint_returns_expected_payload() -> None:
         {"user": "alice", "total_tokens": 100},
         {"user": "bob", "total_tokens": 50},
     ]
+
+
+def test_raw_data_endpoint_returns_all_data_without_filters() -> None:
+    """Test that /analytics/raw_data returns all data when no query parameters are provided."""
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    dummy_service = DummyUsageAnalyticsService()
+    app.dependency_overrides[get_usage_analytics_service] = lambda: dummy_service
+
+    client = TestClient(app)
+
+    response = client.get("/analytics/raw_data")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["user"] == "alice"
+    assert data[1]["user"] == "bob"
+
+
+def test_raw_data_endpoint_filters_by_user() -> None:
+    """Test that /analytics/raw_data correctly filters by user parameter."""
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    dummy_service = DummyUsageAnalyticsService()
+    app.dependency_overrides[get_usage_analytics_service] = lambda: dummy_service
+
+    client = TestClient(app)
+
+    response = client.get("/analytics/raw_data?user=alice")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["user"] == "alice"
+
+
+def test_raw_data_endpoint_filters_by_start_date() -> None:
+    """Test that /analytics/raw_data correctly filters by start_date parameter."""
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    dummy_service = DummyUsageAnalyticsService()
+    app.dependency_overrides[get_usage_analytics_service] = lambda: dummy_service
+
+    client = TestClient(app)
+
+    response = client.get("/analytics/raw_data?start_date=2024-01-02")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["user"] == "bob"
+
+
+def test_raw_data_endpoint_filters_by_end_date() -> None:
+    """Test that /analytics/raw_data correctly filters by end_date parameter."""
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    dummy_service = DummyUsageAnalyticsService()
+    app.dependency_overrides[get_usage_analytics_service] = lambda: dummy_service
+
+    client = TestClient(app)
+
+    response = client.get("/analytics/raw_data?end_date=2024-01-01T23:59:59Z")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["user"] == "alice"
+
+
+def test_raw_data_endpoint_filters_by_multiple_parameters() -> None:
+    """Test that /analytics/raw_data correctly applies multiple filters."""
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    dummy_service = DummyUsageAnalyticsService()
+    app.dependency_overrides[get_usage_analytics_service] = lambda: dummy_service
+
+    client = TestClient(app)
+
+    response = client.get("/analytics/raw_data?start_date=2024-01-01&end_date=2024-01-01T23:59:59Z&user=alice")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["user"] == "alice"
+
+
+def test_raw_data_endpoint_returns_empty_list_when_no_matches() -> None:
+    """Test that /analytics/raw_data returns empty list when no data matches filters."""
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    dummy_service = DummyUsageAnalyticsService()
+    app.dependency_overrides[get_usage_analytics_service] = lambda: dummy_service
+
+    client = TestClient(app)
+
+    response = client.get("/analytics/raw_data?user=nonexistent")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 0
+
+
+def test_raw_data_endpoint_filters_by_model() -> None:
+    """Test that /analytics/raw_data correctly filters by model parameter."""
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    dummy_service = DummyUsageAnalyticsService()
+    app.dependency_overrides[get_usage_analytics_service] = lambda: dummy_service
+
+    client = TestClient(app)
+
+    response = client.get("/analytics/raw_data?model=gpt-4")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["model"] == "gpt-4"
+    assert data[0]["user"] == "alice"
+
+
+def test_raw_data_endpoint_filters_by_user_and_model() -> None:
+    """Test that /analytics/raw_data correctly applies user and model filters together."""
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    dummy_service = DummyUsageAnalyticsService()
+    app.dependency_overrides[get_usage_analytics_service] = lambda: dummy_service
+
+    client = TestClient(app)
+
+    response = client.get("/analytics/raw_data?user=alice&model=gpt-4")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["user"] == "alice"
+    assert data[0]["model"] == "gpt-4"
+
+
+def test_raw_data_endpoint_filters_by_all_parameters_including_model() -> None:
+    """Test that /analytics/raw_data correctly applies all filters including model."""
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    dummy_service = DummyUsageAnalyticsService()
+    app.dependency_overrides[get_usage_analytics_service] = lambda: dummy_service
+
+    client = TestClient(app)
+
+    response = client.get("/analytics/raw_data?start_date=2024-01-01&end_date=2024-01-01T23:59:59Z&user=alice&model=gpt-4")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["user"] == "alice"
+    assert data[0]["model"] == "gpt-4"
 

--- a/backend/app/tests/test_usage_analytics_service.py
+++ b/backend/app/tests/test_usage_analytics_service.py
@@ -72,3 +72,403 @@ def test_events_per_day_aggregates_requests() -> None:
         {"date": datetime(2024, 1, 2, tzinfo=timezone.utc).date(), "requests_count": 5},
     ]
 
+
+def test_get_raw_data_returns_all_data_when_no_filters() -> None:
+    """Test that get_raw_data returns all data when no filters are applied."""
+    repository = DummyCSVUsageRepository(
+        [
+            UsageEventDTO(
+                date=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-4",
+                max_mode="auto",
+                input_with_cache=10,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=15,
+                total_tokens=25,
+                requests=1,
+            ),
+            UsageEventDTO(
+                date=datetime(2024, 1, 2, 9, 0, tzinfo=timezone.utc),
+                user="bob",
+                kind="chat",
+                model="gpt-3.5",
+                max_mode="auto",
+                input_with_cache=5,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=10,
+                total_tokens=15,
+                requests=2,
+            ),
+        ]
+    )
+
+    service = UsageAnalyticsService(repository)
+    dataframe = service.get_raw_data()
+
+    assert len(dataframe) == 2
+    assert dataframe.iloc[0]["user"] == "bob"  # Should be sorted by date descending
+    assert dataframe.iloc[1]["user"] == "alice"
+
+
+def test_get_raw_data_filters_by_start_date() -> None:
+    """Test that get_raw_data correctly filters by start date."""
+    repository = DummyCSVUsageRepository(
+        [
+            UsageEventDTO(
+                date=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-4",
+                max_mode="auto",
+                input_with_cache=10,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=15,
+                total_tokens=25,
+                requests=1,
+            ),
+            UsageEventDTO(
+                date=datetime(2024, 1, 3, 9, 0, tzinfo=timezone.utc),
+                user="bob",
+                kind="chat",
+                model="gpt-3.5",
+                max_mode="auto",
+                input_with_cache=5,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=10,
+                total_tokens=15,
+                requests=2,
+            ),
+        ]
+    )
+
+    service = UsageAnalyticsService(repository)
+    dataframe = service.get_raw_data(start_date="2024-01-02")
+
+    assert len(dataframe) == 1
+    assert dataframe.iloc[0]["user"] == "bob"
+
+
+def test_get_raw_data_filters_by_end_date() -> None:
+    """Test that get_raw_data correctly filters by end date."""
+    repository = DummyCSVUsageRepository(
+        [
+            UsageEventDTO(
+                date=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-4",
+                max_mode="auto",
+                input_with_cache=10,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=15,
+                total_tokens=25,
+                requests=1,
+            ),
+            UsageEventDTO(
+                date=datetime(2024, 1, 3, 9, 0, tzinfo=timezone.utc),
+                user="bob",
+                kind="chat",
+                model="gpt-3.5",
+                max_mode="auto",
+                input_with_cache=5,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=10,
+                total_tokens=15,
+                requests=2,
+            ),
+        ]
+    )
+
+    service = UsageAnalyticsService(repository)
+    dataframe = service.get_raw_data(end_date="2024-01-02")
+
+    assert len(dataframe) == 1
+    assert dataframe.iloc[0]["user"] == "alice"
+
+
+def test_get_raw_data_filters_by_user() -> None:
+    """Test that get_raw_data correctly filters by user."""
+    repository = DummyCSVUsageRepository(
+        [
+            UsageEventDTO(
+                date=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-4",
+                max_mode="auto",
+                input_with_cache=10,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=15,
+                total_tokens=25,
+                requests=1,
+            ),
+            UsageEventDTO(
+                date=datetime(2024, 1, 2, 9, 0, tzinfo=timezone.utc),
+                user="bob",
+                kind="chat",
+                model="gpt-3.5",
+                max_mode="auto",
+                input_with_cache=5,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=10,
+                total_tokens=15,
+                requests=2,
+            ),
+        ]
+    )
+
+    service = UsageAnalyticsService(repository)
+    dataframe = service.get_raw_data(user="alice")
+
+    assert len(dataframe) == 1
+    assert dataframe.iloc[0]["user"] == "alice"
+
+
+def test_get_raw_data_filters_by_date_range_and_user() -> None:
+    """Test that get_raw_data correctly applies multiple filters."""
+    repository = DummyCSVUsageRepository(
+        [
+            UsageEventDTO(
+                date=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-4",
+                max_mode="auto",
+                input_with_cache=10,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=15,
+                total_tokens=25,
+                requests=1,
+            ),
+            UsageEventDTO(
+                date=datetime(2024, 1, 2, 9, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-3.5",
+                max_mode="auto",
+                input_with_cache=5,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=10,
+                total_tokens=15,
+                requests=2,
+            ),
+            UsageEventDTO(
+                date=datetime(2024, 1, 3, 9, 0, tzinfo=timezone.utc),
+                user="bob",
+                kind="chat",
+                model="gpt-3.5",
+                max_mode="auto",
+                input_with_cache=5,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=10,
+                total_tokens=15,
+                requests=2,
+            ),
+        ]
+    )
+
+    service = UsageAnalyticsService(repository)
+    dataframe = service.get_raw_data(start_date="2024-01-02", end_date="2024-01-02", user="alice")
+
+    assert len(dataframe) == 1
+    assert dataframe.iloc[0]["user"] == "alice"
+    assert dataframe.iloc[0]["date"] == datetime(2024, 1, 2, 9, 0, tzinfo=timezone.utc)
+
+
+def test_get_raw_data_returns_empty_dataframe_when_no_matches() -> None:
+    """Test that get_raw_data returns empty dataframe when no data matches filters."""
+    repository = DummyCSVUsageRepository(
+        [
+            UsageEventDTO(
+                date=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-4",
+                max_mode="auto",
+                input_with_cache=10,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=15,
+                total_tokens=25,
+                requests=1,
+            ),
+        ]
+    )
+
+    service = UsageAnalyticsService(repository)
+    dataframe = service.get_raw_data(user="nonexistent_user")
+
+    assert len(dataframe) == 0
+    assert list(dataframe.columns) == [
+        "date", "user", "kind", "model", "max_mode", "input_with_cache",
+        "input_without_cache", "cache_read", "output_tokens", "total_tokens", "requests"
+    ]
+
+
+def test_get_raw_data_filters_by_model() -> None:
+    """Test that get_raw_data correctly filters by model."""
+    repository = DummyCSVUsageRepository(
+        [
+            UsageEventDTO(
+                date=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-4",
+                max_mode="auto",
+                input_with_cache=10,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=15,
+                total_tokens=25,
+                requests=1,
+            ),
+            UsageEventDTO(
+                date=datetime(2024, 1, 2, 9, 0, tzinfo=timezone.utc),
+                user="bob",
+                kind="chat",
+                model="gpt-3.5",
+                max_mode="auto",
+                input_with_cache=5,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=10,
+                total_tokens=15,
+                requests=2,
+            ),
+        ]
+    )
+
+    service = UsageAnalyticsService(repository)
+    dataframe = service.get_raw_data(model="gpt-4")
+
+    assert len(dataframe) == 1
+    assert dataframe.iloc[0]["model"] == "gpt-4"
+    assert dataframe.iloc[0]["user"] == "alice"
+
+
+def test_get_raw_data_filters_by_user_and_model() -> None:
+    """Test that get_raw_data correctly applies user and model filters together."""
+    repository = DummyCSVUsageRepository(
+        [
+            UsageEventDTO(
+                date=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-4",
+                max_mode="auto",
+                input_with_cache=10,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=15,
+                total_tokens=25,
+                requests=1,
+            ),
+            UsageEventDTO(
+                date=datetime(2024, 1, 2, 9, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-3.5",
+                max_mode="auto",
+                input_with_cache=5,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=10,
+                total_tokens=15,
+                requests=2,
+            ),
+            UsageEventDTO(
+                date=datetime(2024, 1, 3, 9, 0, tzinfo=timezone.utc),
+                user="bob",
+                kind="chat",
+                model="gpt-4",
+                max_mode="auto",
+                input_with_cache=5,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=10,
+                total_tokens=15,
+                requests=2,
+            ),
+        ]
+    )
+
+    service = UsageAnalyticsService(repository)
+    dataframe = service.get_raw_data(user="alice", model="gpt-4")
+
+    assert len(dataframe) == 1
+    assert dataframe.iloc[0]["user"] == "alice"
+    assert dataframe.iloc[0]["model"] == "gpt-4"
+
+
+def test_get_raw_data_filters_by_all_parameters() -> None:
+    """Test that get_raw_data correctly applies all filters together."""
+    repository = DummyCSVUsageRepository(
+        [
+            UsageEventDTO(
+                date=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-4",
+                max_mode="auto",
+                input_with_cache=10,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=15,
+                total_tokens=25,
+                requests=1,
+            ),
+            UsageEventDTO(
+                date=datetime(2024, 1, 2, 9, 0, tzinfo=timezone.utc),
+                user="alice",
+                kind="chat",
+                model="gpt-4",
+                max_mode="auto",
+                input_with_cache=5,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=10,
+                total_tokens=15,
+                requests=2,
+            ),
+            UsageEventDTO(
+                date=datetime(2024, 1, 3, 9, 0, tzinfo=timezone.utc),
+                user="bob",
+                kind="chat",
+                model="gpt-3.5",
+                max_mode="auto",
+                input_with_cache=5,
+                input_without_cache=0,
+                cache_read=0,
+                output_tokens=10,
+                total_tokens=15,
+                requests=2,
+            ),
+        ]
+    )
+
+    service = UsageAnalyticsService(repository)
+    dataframe = service.get_raw_data(
+        start_date="2024-01-02", 
+        end_date="2024-01-02", 
+        user="alice", 
+        model="gpt-4"
+    )
+
+    assert len(dataframe) == 1
+    assert dataframe.iloc[0]["user"] == "alice"
+    assert dataframe.iloc[0]["model"] == "gpt-4"
+    assert dataframe.iloc[0]["date"] == datetime(2024, 1, 2, 9, 0, tzinfo=timezone.utc)
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ pandas>=2.3,<3.0
 pydantic>=2.7,<3.0
 fastapi>=0.111,<1.0
 httpx>=0.27,<1.0
+pytest>=8.0,<9.0

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -3,21 +3,29 @@ import pandas as pd
 import plotly.express as px
 import requests
 from requests import HTTPError
+import time
 
 BACKEND_URL = "http://backend:8000"
 ANALYTICS_ENDPOINTS = {
     "events_per_day": "/analytics/events_per_day",
     "tokens_per_user": "/analytics/tokens_per_user",
     "tokens_by_model": "/analytics/tokens_by_model",
+    "raw_data": "/analytics/raw_data",
 }
 
 
-def fetch_dataframe(endpoint: str) -> pd.DataFrame:
+def fetch_dataframe(endpoint: str, params: dict = None) -> pd.DataFrame:
     """Retrieve analytics data from the backend and convert to a dataframe."""
 
     url = f"{BACKEND_URL}{endpoint}"
+    
+    # Add timestamp to avoid browser caching
+    if params is None:
+        params = {}
+    params["_t"] = str(int(time.time()))
+    
     try:
-        response = requests.get(url, timeout=10)
+        response = requests.get(url, params=params, timeout=10)
         response.raise_for_status()
     except HTTPError as exc:  # pragma: no cover - streamlit app runtime handling
         st.error(f"Failed to load data from {url}: {exc}")
@@ -49,20 +57,147 @@ def get_tokens_by_model() -> pd.DataFrame:
     return fetch_dataframe(ANALYTICS_ENDPOINTS["tokens_by_model"])
 
 
+@st.cache_data(show_spinner=False)
+def get_raw_data(start_date: str = None, end_date: str = None, user: str = None, model: str = None) -> pd.DataFrame:
+    params = {}
+    if start_date:
+        params["start_date"] = start_date
+    if end_date:
+        params["end_date"] = end_date
+    if user:
+        params["user"] = user
+    if model:
+        params["model"] = model
+    
+    return fetch_dataframe(ANALYTICS_ENDPOINTS["raw_data"], params)
+
+
 st.set_page_config(page_title="Cursor Usage Analytics", layout="wide")
 st.title("Cursor Usage Analytics Dashboard")
 
 # Add a refresh button to clear cache and reload data
 if st.button("🔄 Обновить данные", help="Обновить данные из CSV файла"):
+    # Clear all cached data
     st.cache_data.clear()
+    # Force rerun to reload all data
     st.rerun()
 
 
-events_tab, users_tab, models_tab = st.tabs([
-    "Events per day",
-    "Tokens per user",
-    "Tokens by model",
+raw_data_tab, events_tab, users_tab, models_tab = st.tabs([
+    "📊 Сырые данные",
+    "📈 Events per day",
+    "👥 Tokens per user",
+    "🤖 Tokens by model",
 ])
+
+with raw_data_tab:
+    st.header("📊 Сырые данные")
+    
+    # Create filter controls
+    col1, col2, col3, col4 = st.columns([2, 2, 2, 2])
+    
+    with col1:
+        start_date = st.date_input(
+            "📅 Дата начала",
+            value=None,
+            help="Выберите дату начала периода"
+        )
+    
+    with col2:
+        end_date = st.date_input(
+            "📅 Дата окончания",
+            value=None,
+            help="Выберите дату окончания периода"
+        )
+    
+    # Get unique users and models for the filters
+    all_raw_data = get_raw_data()  # Get all data to extract unique values
+    unique_users = ["Все пользователи"] + sorted(all_raw_data["user"].unique().tolist()) if not all_raw_data.empty else ["Все пользователи"]
+    unique_models = ["Все модели"] + sorted(all_raw_data["model"].unique().tolist()) if not all_raw_data.empty else ["Все модели"]
+    
+    with col3:
+        selected_user = st.selectbox(
+            "👤 Пользователь",
+            options=unique_users,
+            help="Выберите пользователя для фильтрации"
+        )
+    
+    with col4:
+        selected_model = st.selectbox(
+            "🤖 Модель",
+            options=unique_models,
+            help="Выберите модель для фильтрации"
+        )
+    
+    # Prepare filter parameters
+    start_date_str = start_date.isoformat() if start_date else None
+    end_date_str = end_date.isoformat() if end_date else None
+    user_filter = selected_user if selected_user != "Все пользователи" else None
+    model_filter = selected_model if selected_model != "Все модели" else None
+    
+    # Fetch filtered data
+    raw_df = get_raw_data(start_date=start_date_str, end_date=end_date_str, user=user_filter, model=model_filter)
+    
+    if not raw_df.empty:
+        # Display summary metrics
+        col1, col2, col3, col4 = st.columns(4)
+        
+        with col1:
+            st.metric("📝 Всего записей", len(raw_df))
+        
+        with col2:
+            st.metric("👥 Пользователей", raw_df["user"].nunique())
+        
+        with col3:
+            total_tokens = raw_df["total_tokens"].sum()
+            st.metric("🔢 Всего токенов", f"{total_tokens:,}")
+        
+        with col4:
+            total_requests = raw_df["requests"].sum()
+            st.metric("📊 Всего запросов", f"{total_requests:,}")
+        
+        st.divider()
+        
+        # Format the dataframe for better display
+        display_df = raw_df.copy()
+        
+        # Convert date to more readable format
+        if "date" in display_df.columns:
+            display_df["date"] = pd.to_datetime(display_df["date"]).dt.strftime("%Y-%m-%d %H:%M:%S")
+        
+        # Rename columns to Russian
+        column_mapping = {
+            "date": "Дата",
+            "user": "Пользователь",
+            "kind": "Тип",
+            "model": "Модель",
+            "max_mode": "Макс. режим",
+            "input_with_cache": "Ввод (с кэшем)",
+            "input_without_cache": "Ввод (без кэша)",
+            "cache_read": "Чтение кэша",
+            "output_tokens": "Выходные токены",
+            "total_tokens": "Всего токенов",
+            "requests": "Запросы"
+        }
+        
+        display_df = display_df.rename(columns=column_mapping)
+        
+        # Display the table
+        st.dataframe(
+            display_df,
+            use_container_width=True,
+            hide_index=True,
+            column_config={
+                "Дата": st.column_config.TextColumn("Дата", width="medium"),
+                "Пользователь": st.column_config.TextColumn("Пользователь", width="medium"),
+                "Модель": st.column_config.TextColumn("Модель", width="small"),
+                "Всего токенов": st.column_config.NumberColumn("Всего токенов", format="%d"),
+                "Выходные токены": st.column_config.NumberColumn("Выходные токены", format="%d"),
+                "Запросы": st.column_config.NumberColumn("Запросы", format="%d"),
+            }
+        )
+    else:
+        st.info("📭 Нет данных для отображения с выбранными фильтрами")
 
 with events_tab:
     st.header("Events per day")


### PR DESCRIPTION
…и модели

- Добавлен новый API эндпоинт /analytics/raw_data с поддержкой фильтрации
- Реализованы фильтры по диапазону дат, пользователю и модели
- Добавлен новый таб в frontend с таблицей сырых данных
- Исправлено кэширование данных с timestamp параметром
- Добавлен pytest в зависимости и обновлен Dockerfile
- Полное покрытие тестами нового функционала (12 новых тестов)
- Улучшена кнопка обновления данных для очистки кэша

Новые возможности:
- 📊 Таб 'Сырые данные' с полной таблицей
- 📅 Фильтр по диапазону дат
- 👤 Фильтр по пользователю
- 🤖 Фильтр по модели
- 📈 Метрики: записи, пользователи, токены, запросы
- 🔄 Обновление данных без пересборки контейнеров